### PR TITLE
More explicit errors for PAT token

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -109,7 +109,7 @@ describe('action', () => {
     // Verify that all of the core library functions were called correctly
     expect(setFailedMock).toHaveBeenNthCalledWith(
       1,
-      'github_pat_token not in a valid format'
+      'github_pat_token does not start with ghp_'
     )
   })
 
@@ -138,7 +138,7 @@ describe('action', () => {
     // Verify that all of the core library functions were called correctly
     expect(setFailedMock).toHaveBeenNthCalledWith(
       1,
-      'github_pat_token not in a valid format'
+      'github_pat_token contains special characters'
     )
   })
 
@@ -167,7 +167,7 @@ describe('action', () => {
     // Verify that all of the core library functions were called correctly
     expect(setFailedMock).toHaveBeenNthCalledWith(
       1,
-      'github_pat_token not in a valid format'
+      'github_pat_token not 40 characters long'
     )
   })
 
@@ -303,6 +303,10 @@ describe('action', () => {
           return 'archive_test'
         case 'github_repo_max_inactive_days':
           return '365'
+        case 'ignore_files':
+          return 'README.md'
+        case 'readme_message':
+          return 'This is a test message'
         default:
           return ''
       }
@@ -319,13 +323,18 @@ describe('action', () => {
     expect(debugMock).toHaveBeenNthCalledWith(2, 'github_org: robertcrockett')
     expect(debugMock).toHaveBeenNthCalledWith(3, 'github_repo: archive_test')
     expect(debugMock).toHaveBeenNthCalledWith(4, 'inactive_days: 365')
-    expect(debugMock).toHaveBeenNthCalledWith(5, 'Waiting 500 milliseconds ...')
+    expect(debugMock).toHaveBeenNthCalledWith(5, 'ignore_files: README.md')
     expect(debugMock).toHaveBeenNthCalledWith(
       6,
+      'readme_message: This is a test message'
+    )
+    expect(debugMock).toHaveBeenNthCalledWith(7, 'Waiting 500 milliseconds ...')
+    expect(debugMock).toHaveBeenNthCalledWith(
+      8,
       expect.stringMatching(timeRegex)
     )
     expect(debugMock).toHaveBeenNthCalledWith(
-      7,
+      9,
       expect.stringMatching(timeRegex)
     )
     expect(setOutputMock).toHaveBeenNthCalledWith(
@@ -335,7 +344,7 @@ describe('action', () => {
     )
   })
 
-  it('sets a failed status', async () => {
+  it('sets a failed status if milliseconds is not a number', async () => {
     // Set the action's inputs as return values from core.getInput()
     getInputMock.mockImplementation(name => {
       switch (name) {

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,17 @@ inputs:
       archived'
     required: true
     default: '730'
+  ignore_files:
+    description:
+      'A list of files to ignore when determining if a repository is inactive'
+    required: false
+    default: '[]'
+  readme_message:
+    description:
+      'The message to add to the README.md file of the repository when it is
+      archived'
+    required: false
+    default: 'This repository has been archived due to inactivity. It will no longer be maintained moving forward.'
 
 # Define your outputs here.
 outputs:

--- a/src/main.js
+++ b/src/main.js
@@ -17,10 +17,15 @@ async function run() {
     const inactive_days = core.getInput('github_repo_max_inactive_days', {
       required: true
     })
+    const ignore_files = core.getInput('ignore_files', { required: false })
+    const readme_message = core.getInput('readme_message', { required: false })
 
     // Validate the github_pat_token
-    if (!validate_token(github_pat_token)) {
-      throw new Error('github_pat_token not in a valid format')
+    try {
+      validate_token(github_pat_token)
+    } catch (error) {
+      console.log('Error validating PAT token: ', error.message)
+      throw error
     }
     // Validate that the inactive_days variable is a number
     if (isNaN(inactive_days)) {
@@ -32,6 +37,8 @@ async function run() {
     core.debug(`github_org: ${github_org}`)
     core.debug(`github_repo: ${github_repo}`)
     core.debug(`inactive_days: ${inactive_days}`)
+    core.debug(`ignore_files: ${ignore_files}`)
+    core.debug(`readme_message: ${readme_message}`)
     core.debug(`Waiting ${ms} milliseconds ...`)
 
     // Log the current timestamp, wait, then log the new timestamp
@@ -56,11 +63,17 @@ async function run() {
 function validate_token(github_pat_token) {
   // A regular expression that starts with ghp_, is alphanumeric with NO special characters and is exactly 40 characters long
   const pat_regex = /^ghp_[a-zA-Z0-9]{36}$/
+  const pat_length = 40
+  const pat_start = 'ghp_'
 
-  if (github_pat_token.match(pat_regex)) {
-    return true
+  if (github_pat_token.length !== pat_length) {
+    throw new Error('github_pat_token not 40 characters long')
+  } else if (!github_pat_token.startsWith(pat_start)) {
+    throw new Error('github_pat_token does not start with ghp_')
+  } else if (!github_pat_token.match(pat_regex)) {
+    throw new Error('github_pat_token contains special characters')
   } else {
-    return false
+    return true
   }
 }
 


### PR DESCRIPTION
Added additional validation for PAT tokens:

1. invalid PAT length
2. Invalid start of PAT
3. Invalid use of special characters

All tests pass.